### PR TITLE
Implemented image_hook_supported_extensions

### DIFF
--- a/imagemagick.module
+++ b/imagemagick.module
@@ -533,6 +533,13 @@ function _imagemagick_convert_exec($command_args, &$output = NULL, &$error = NUL
 }
 
 /**
+ * Imlements image_hook_supported_extensions
+ */
+function image_imagemagick_supported_extensions() {
+  return ['png', 'gif', 'jpg', 'jpeg', 'webp'];
+}
+
+/**
  * @} End of "ingroup image".
  */
 


### PR DESCRIPTION
Without this hook implemented you get a lot of this error: The selected image handling toolkit imagemagick should provide a image_imagemagick_supported_extensions callback.

Imagemagick supports many more extensions, but since these are the ones that the GD module supports, I thought it would be safest to stick with these.